### PR TITLE
Add rate limiting (hard-coded) to whois requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ The data should conform to the [JSON schema](./rules.schema.json):
 ### Command-line parameters
 Script accepts two arguments: `pagenum` (starts at 0) and `pagesize`. If these are not provided, then the whole list inside the CSV will be processed.
 
+### Rate Limiting
+The library has some hard-coded rate limits for now. You can change the rate limits by changing the values in the main.py file.
+Specifically the global variables at the top of the file `RATELIMIT_REQUESTS` and `RATELIMIT_TIMERANGE`.
+These values define how many requests may be made within a specific time range (for example, 5 requests every 20 seconds).
+As of right now, there's no way to adjust these dynamically per invocation of the program based on command line parameters - it must be done with hard-coded values.
+
 ## Localhost
 Before you can run the program, you should create a virtual environment for the python executable
 ```bash

--- a/main.py
+++ b/main.py
@@ -65,8 +65,10 @@ def parse_input(json_data: Any) -> None:
 
 
 # Adding throttling
-# This is actually very basic. The whois library sends queries to the appropriate NIC servers, so we're overly-throttling here.
-# More logic could be added to ask the whois library WHICH server the domain's request would be sent to, and then throttle per-server.
+# This is actually very basic.
+# The whois library sends queries to the appropriate NIC servers, so we're overly-throttling here.
+# More logic could be added to ask the whois library:
+#   WHICH server the domain's request would be sent to, and then throttle per-server.
 # This would likely be done by creating a NICClient, then using client.choose_server
 @sleep_and_retry
 @limits(calls=RATELIMIT_REQUESTS, period=RATELIMIT_TIMERANGE)

--- a/main.py
+++ b/main.py
@@ -15,8 +15,8 @@ from error import WhoisScannerException, ErrorCodes
 from db import Db
 
 # Basic rate limiting: 5 requests per 20 seconds
-RATELIMIT_REQUESTS=5    # Number of requests to rate limit
-RATELIMIT_TIMERANGE=20  # Amount of time to rate limit
+RATELIMIT_REQUESTS = 5    # Number of requests to rate limit
+RATELIMIT_TIMERANGE = 20  # Amount of time to rate limit
 SCHEMA_FILE = "rules.schema.json"
 RULES_FILE = "rules.json"
 DOMAINS_FILE = "input.csv"
@@ -99,9 +99,10 @@ def extract_domains(input_data: Any, pagenum: int, pagesize: int) -> List[str]:
     '''Pull domain list out of the input file data'''
     if pagesize is None:
         return input_data
-    start=pagesize*pagenum
-    stop=pagesize*(pagenum+1)
-    specific_rows=[row for idx, row in enumerate(input_data) if idx in range(start, stop)]
+    start = pagesize*pagenum
+    stop = pagesize*(pagenum+1)
+    specific_rows = [row for idx, row in enumerate(
+        input_data) if idx in range(start, stop)]
     return [row["input_url"] for row in specific_rows]
 
 

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ import sys
 from typing import Any, List, Tuple
 
 import jsonschema
+from pyrate_limiter import BucketFullException, Duration, Limiter, Rate
 import whois
 
 from error import WhoisScannerException, ErrorCodes
@@ -60,9 +61,14 @@ def parse_input(json_data: Any) -> None:
         raise WhoisScannerException(ErrorCodes.BAD_INPUT_FILE) from ex
 
 
-def lookup(domain: str) -> Any:
+# Adding throttling
+# This is actually very basic. The whois library sends queries to the appropriate NIC servers, so we're overly-throttling here.
+# More logic could be added to ask the whois library WHICH server the domain's request would be sent to, and then throttle per-server.
+# This would likely be done by creating a NICClient, then using client.choose_server
+def lookup(domain: str, limiter: Limiter) -> Any:
     '''Perform the whois lookup'''
     try:
+        limiter.try_acquire(domain)
         resp = whois.whois(domain)
         return resp
     except whois.parser.PywhoisError as ex:
@@ -70,6 +76,8 @@ def lookup(domain: str) -> Any:
             raise WhoisScannerException(
                 ErrorCodes.HOSTNAME_DOES_NOT_EXIST) from ex
         raise ex
+    except BucketFullException as err:
+        raise err #TODO: Handle better?
 
 
 def extract_registrant_data(whois_result: Any) -> Tuple[str, str]:
@@ -129,6 +137,10 @@ def main(pagenum: int, pagesize: int) -> int:
         log.exception(ex)
         return -1
 
+    # TODO: Hard-coded limiter
+    rate = Rate(5, Duration.SECOND * 10)
+    limiter = Limiter(rate, max_delay=5000)
+
     index = 0
     log.info("Begin whois lookup for %d hostnames", len(domains))
     for domain in domains:
@@ -137,7 +149,7 @@ def main(pagenum: int, pagesize: int) -> int:
                 "Processing host [%d of %d] (will output every 10)", index, len(domains))
         try:
             log.debug("Looking up hostname %s", domain)
-            whois_result = lookup(domain)
+            whois_result = lookup(domain, limiter)
             (name, country) = extract_registrant_data(whois_result)
             privacy_term_match = name_privacy_match(terms, name)
             if privacy_term_match is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 python-whois
 jsonschema
+pyrate-limiter

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 python-whois
 jsonschema
-pyrate-limiter
+ratelimit


### PR DESCRIPTION
Uses the [ratelimit](https://github.com/tomasbasham/ratelimit/tree/master) library, which is very old and unmaintained, but does work.

Rate limiting is done through hard-coded variables at the top of the main.py file.